### PR TITLE
fix(customTOC): height resize correction for postmessage re #8701

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ MCourserCommunication.prototype.updateIFrameHeight = function (newHeight) {
         throw new Error('This communication is not initialized!');
     }
 
-    this.top.postMessage('mCurriculum_RESIZE:0:' + newHeight, '*');
+    this.parent.postMessage('mCurriculum_RESIZE:0:' + newHeight, '*');
 };
 
 MCourserCommunication.prototype.requestCollectionsData = function () {


### PR DESCRIPTION
re #learneticsa/mcourser/8701

Użytkownik
Login: teacherTEST0030

Hasło: t

wersja testowa: https://test-8701-dot-mcourser-dev.appspot.com

Przechodzimy do https://ubbleai.github.io/iframe-tester/, odpalamy w nim https://ubbleai.github.io/iframe-tester/ jako kolejny iframe, a w nim https://test-8701-dot-mcourser-dev.appspot.com/courses/5630669047726080/next/~courses~list~type~all?display=custom. Widzimy, że customTOC się ładuje i nie ma uciętej wysokości. Gdy odpalimy wersję testową bez iframe, to oczywiście też customTOC działa. 